### PR TITLE
Update import path of github_flavored_markdown package.

### DIFF
--- a/wikihelper/wikihelper.go
+++ b/wikihelper/wikihelper.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/shurcooL/go/github_flavored_markdown"
+	"github.com/shurcooL/github_flavored_markdown"
 )
 
 func UrlEncode(str string) (encoded string) {


### PR DESCRIPTION
It has moved out into a standalone repo recently. See https://github.com/shurcooL/go/issues/19#issuecomment-102574426 for rationale.
